### PR TITLE
Provide `liftFn` to turn a fn into a promise resolution handler.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = (iterable, mapper, opts) => new Promise((resolve, reject) => {
 	}
 });
 
-module.exports.liftFn = function(mapper, options) {
+module.exports.thunk = function(mapper, options) {
 	return function(input){
 		module.exports(input, mapper, options);
 	};

--- a/index.js
+++ b/index.js
@@ -58,3 +58,9 @@ module.exports = (iterable, mapper, opts) => new Promise((resolve, reject) => {
 		}
 	}
 });
+
+module.exports.liftFn = function(mapper, options) {
+	return function(input){
+		module.exports(input, mapper, options);
+	};
+}


### PR DESCRIPTION
Hi @sindresorhus, I love your p-* libs use, but I find that most often, I want to be building interesting promise chains.

`getTimeNow().then( addTime("2 weeks")).then (lookupCalendar()).then(lookForConflicts).then(notify("email"))` is the kind of promise based data-flow system that promises usually have me creating.

The `liftFn` provided here allows for that fluent-style usage of p-map, taking the static elements- the mapper & whatever options- and lifting them into a handler that is called for each input.

`Promise.resolve([1,2,3]).then( pMap.liftFn( x=> x* 3).then( console.log)` ought log `[3,6,9]`.

This vs:
```
var input= Promise.resolve([1,2,3])
var output= pMap( input, x=> x* 3).then( console.log)
```