### PR TITLE
Removed index parameter, each call to next now increase index by one

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,13 +15,16 @@ module.exports = (iterable, mapper, opts) => new Promise((resolve, reject) => {
 	let isRejected = false;
 	let iterableDone = false;
 	let resolvingCount = 0;
+	let currentIdx = 0;
 
-	const next = i => {
+	const next = () => {
 		if (isRejected) {
 			return;
 		}
 
 		const nextItem = iterator.next();
+		const i = currentIdx;
+		currentIdx++;
 
 		if (nextItem.done) {
 			iterableDone = true;
@@ -41,7 +44,7 @@ module.exports = (iterable, mapper, opts) => new Promise((resolve, reject) => {
 				val => {
 					ret[i] = val;
 					resolvingCount--;
-					next(i + concurrency);
+					next();
 				},
 				err => {
 					isRejected = true;
@@ -51,7 +54,7 @@ module.exports = (iterable, mapper, opts) => new Promise((resolve, reject) => {
 	};
 
 	for (let i = 0; i < concurrency; i++) {
-		next(i);
+		next();
 
 		if (iterableDone) {
 			break;

--- a/test.js
+++ b/test.js
@@ -16,13 +16,13 @@ const mapper = ([val, ms]) => delay(ms).then(() => val);
 test('main', async t => {
 	const end = timeSpan();
 	t.deepEqual(await m(input, mapper), [10, 20, 30]);
-	t.true(inRange(end(), 290, 330));
+	t.true(inRange(end(), 290, 430));
 });
 
 test('concurrency: 1', async t => {
 	const end = timeSpan();
 	t.deepEqual(await m(input, mapper, {concurrency: 1}), [10, 20, 30]);
-	t.true(inRange(end(), 590, 660));
+	t.true(inRange(end(), 590, 760));
 });
 
 test('concurrency: 4', async t => {
@@ -42,12 +42,8 @@ test('handles empty iterable', async t => {
 });
 
 test('async with concurrency: 2', async t => {
-	const myInput = [100, 200, 10, 36, 13, 45];
-	const myMapper = value => {
-		return new Promise(resolve => {
-			setTimeout(() => resolve(value), value);
-		});
-	};
-	const result = await m(myInput, myMapper, {concurrency: 2});
-	t.deepEqual(result, myInput);
+	const input = Array(10).map(() => randomInt(0, 100));
+	const mapper = value => delay(value).then(() => value);
+	const result = await m(input, mapper, {concurrency: 2});
+	t.deepEqual(result, input);
 });

--- a/test.js
+++ b/test.js
@@ -41,8 +41,15 @@ test('handles empty iterable', async t => {
 	t.deepEqual(await m([], mapper), []);
 });
 
-test('async with concurrency: 2', async t => {
+test('async with concurrency: 2 (random time sequence)', async t => {
 	const input = Array(10).map(() => randomInt(0, 100));
+	const mapper = value => delay(value).then(() => value);
+	const result = await m(input, mapper, {concurrency: 2});
+	t.deepEqual(result, input);
+});
+
+test('async with concurrency: 2 (problematic time sequence)', async t => {
+	const input = [100, 200, 10, 36, 13, 45];
 	const mapper = value => delay(value).then(() => value);
 	const result = await m(input, mapper, {concurrency: 2});
 	t.deepEqual(result, input);

--- a/test.js
+++ b/test.js
@@ -54,3 +54,10 @@ test('async with concurrency: 2 (problematic time sequence)', async t => {
 	const result = await m(input, mapper, {concurrency: 2});
 	t.deepEqual(result, input);
 });
+
+test('async with concurrency: 2 (out of order time sequence)', async t => {
+	const input = [200, 100, 50];
+	const mapper = value => delay(value).then(() => value);
+	const result = await m(input, mapper, {concurrency: 2});
+	t.deepEqual(result, input);
+});

--- a/test.js
+++ b/test.js
@@ -40,3 +40,14 @@ test('concurrency: 4', async t => {
 test('handles empty iterable', async t => {
 	t.deepEqual(await m([], mapper), []);
 });
+
+test('async with concurrency: 2', async t => {
+	const myInput = [100, 200, 10, 36, 13, 45];
+	const myMapper = value => {
+		return new Promise(resolve => {
+			setTimeout(() => resolve(value), value);
+		});
+	};
+	const result = await m(myInput, myMapper, {concurrency: 2});
+	t.deepEqual(result, myInput);
+});


### PR DESCRIPTION
We access the source as an iterable, so each item we read is subsequent to the last one read.

The previous algorithm pretends that items are randomly accessible, and saving them on wrong position in output array.

This PR calculate the position index of each item in the source input sequentially, so that each item is written in the correct output position.

---

Fixes #4 