### PR TITLE
Add an option to use some other error class in place of AggregateError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import AggregateError = require('aggregate-error');
+
 declare namespace pMap {
 	interface Options {
 		/**
@@ -13,6 +15,13 @@ declare namespace pMap {
 		@default true
 		*/
 		readonly stopOnError?: boolean;
+
+		/**
+		Alternate error class to reject with when `stopOnError` is `false`.
+
+		@default AggregateError
+		*/
+		readonly AggregateError?: new (errors: Error[]) => Error;
 	}
 
 	/**

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
-const AggregateError = require('aggregate-error');
+const _AggregateError = require('aggregate-error');
 
 module.exports = async (
 	iterable,
 	mapper,
 	{
 		concurrency = Infinity,
-		stopOnError = true
+		stopOnError = true,
+		AggregateError = _AggregateError
 	} = {}
 ) => {
 	return new Promise((resolve, reject) => {
@@ -16,6 +17,10 @@ module.exports = async (
 
 		if (!(typeof concurrency === 'number' && concurrency >= 1)) {
 			throw new TypeError(`Expected \`concurrency\` to be a number from 1 and up, got \`${concurrency}\` (${typeof concurrency})`);
+		}
+
+		if (typeof AggregateError !== 'function' || !(AggregateError === Error || AggregateError.prototype instanceof Error)) {
+			throw new TypeError(`Expected \`AggregateError\` to be a constructor function that creates an Error, got \`${AggregateError}\` (${typeof AggregateError})`);
 		}
 
 		const ret = [];

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,3 +1,4 @@
+import AggregateError = require('aggregate-error');
 import {expectType} from 'tsd';
 import pMap = require('.');
 import {Options, Mapper} from '.';
@@ -41,3 +42,6 @@ expectType<Promise<string[]>>(pMap(sites, (site: string) => site));
 expectType<Promise<number[]>>(pMap(sites, (site: string) => site.length));
 
 expectType<Promise<number[]>>(pMap(numbers, (number: number) => number * 2));
+
+pMap(sites, asyncMapper, {AggregateError: AggregateError});
+pMap(sites, asyncMapper, {AggregateError: class extends AggregateError {}});

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,12 @@ Default: `true`
 
 When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
 
+##### AggregateError
+
+Type: `Function`
+
+Alternate error class to reject with when `stopOnError` is `false`. The constructor must accept an array of `Error`s as its sole parameter. The default is [`AggregateError`](https://github.com/sindresorhus/aggregate-error).
+
 
 ## Related
 


### PR DESCRIPTION
For example, the caller might use a subclass of `AggregateError` that [flattens nested `AggregateError`s](https://github.com/sindresorhus/aggregate-error/pull/11).