### PR TITLE
Add support for AsyncIterable as input

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ console.log(result);
 ```
 */
 export default function pMap<Element, NewElement>(
-	input: Iterable<Element>,
+	input: AsyncIterable<Element> | Iterable<Element>,
 	mapper: Mapper<Element, NewElement>,
 	options?: Options
 ): Promise<Array<Exclude<NewElement, typeof pMapSkip>>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export type Mapper<Element = any, NewElement = unknown> = (
 ) => NewElement | Promise<NewElement>;
 
 /**
-@param input - Iterated over concurrently in the `mapper` function.
+@param input - Synchronous or asynchronous iterable that is iterated over concurrently, calling the `mapper` function for each element. Each iterated item is `await`'d before the `mapper` is invoked so the iterable may return a `Promise` that resolves to an item. Asynchronous iterables (different from synchronous iterables that return `Promise` that resolves to an item) can be used when the next item may not be ready without waiting for an asynchronous process to complete and/or the end of the iterable may be reached after the asynchronous process completes. For example, reading from a remote queue when the queue has reached empty, or reading lines from a stream.
 @param mapper - Function which is called for every item in `input`. Expected to return a `Promise` or value.
 @returns A `Promise` that is fulfilled when all promises in `input` and ones returned from `mapper` are fulfilled, or rejects if any of the promises reject. The fulfilled value is an `Array` of the fulfilled values returned from `mapper` in `input` order.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ console.log(result);
 ```
 */
 export default function pMap<Element, NewElement>(
-	input: AsyncIterable<Element> | Iterable<Element>,
+	input: AsyncIterable<Element | Promise<Element>> | Iterable<Element | Promise<Element>>,
 	mapper: Mapper<Element, NewElement>,
 	options?: Options
 ): Promise<Array<Exclude<NewElement, typeof pMapSkip>>>;

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export default async function pMap(
 		const errors = [];
 		const skippedIndexes = [];
 		let isRejected = false;
-		let isRejectedOrResolved = false;
+		let isResolved = false;
 		let isIterableDone = false;
 		let resolvingCount = 0;
 		let currentIndex = 0;
@@ -29,12 +29,12 @@ export default async function pMap(
 
 		const reject = reason => {
 			isRejected = true;
-			isRejectedOrResolved = true;
+			isResolved = true;
 			reject_(reason);
 		};
 
 		const next = async () => {
-			if (isRejectedOrResolved) {
+			if (isResolved) {
 				return;
 			}
 
@@ -52,11 +52,11 @@ export default async function pMap(
 			if (nextItem.done) {
 				isIterableDone = true;
 
-				if (resolvingCount === 0 && !isRejectedOrResolved) {
+				if (resolvingCount === 0 && !isResolved) {
 					if (!stopOnError && errors.length > 0) {
 						reject(new AggregateError(errors));
 					} else {
-						isRejectedOrResolved = true;
+						isResolved = true;
 
 						for (const skippedIndex of skippedIndexes) {
 							result.splice(skippedIndex, 1);
@@ -76,7 +76,7 @@ export default async function pMap(
 				try {
 					const element = await nextItem.value;
 
-					if (isRejectedOrResolved) {
+					if (isResolved) {
 						return;
 					}
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ export default async function pMap(
 
 			resolvingCount++;
 
-			// Intentionally not awaited
+			// Intentionally detached
 			(async () => {
 				try {
 					const element = await nextItem.value;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ export default async function pMap(
 	} = {}
 ) {
 	return new Promise((resolve, reject_) => { // eslint-disable-line promise/param-names
+		if (iterable[Symbol.iterator] === undefined && iterable[Symbol.asyncIterator] === undefined) {
+			throw new TypeError(`Expected \`input\` to be either an \`Iterable\` or \`AsyncIterable\`, got (${typeof iterable})`);
+		}
+
 		if (typeof mapper !== 'function') {
 			throw new TypeError('Mapper function is required');
 		}
@@ -43,8 +47,8 @@ export default async function pMap(
 			const index = currentIndex;
 			currentIndex++;
 
-			// Note: iterator.next() can be called many times in parallel.
-			// This can cause multiple calls to this next() function to
+			// Note: `iterator.next()` can be called many times in parallel.
+			// This can cause multiple calls to this `next()` function to
 			// receive a `nextItem` with `done === true`.
 			// The shutdown logic that rejects/resolves must be protected
 			// so it runs only one time as the `skippedIndex` logic is
@@ -97,9 +101,9 @@ export default async function pMap(
 						errors.push(error);
 						resolvingCount--;
 
-						// In that case we can't really continue regardless of stopOnError state
+						// In that case we can't really continue regardless of `stopOnError` state
 						// since an iterable is likely to continue throwing after it throws once.
-						// If we continue calling next() indefinitely we will likely end up
+						// If we continue calling `next()` indefinitely we will likely end up
 						// in an infinite loop of failed iteration.
 						try {
 							await next();
@@ -112,11 +116,11 @@ export default async function pMap(
 		};
 
 		// Create the concurrent runners in a detached (non-awaited)
-		// promise.  We need this so we can await the next() calls
+		// promise. We need this so we can await the `next()` calls
 		// to stop creating runners before hitting the concurrency limit
 		// if the iterable has already been marked as done.
 		// NOTE: We *must* do this for async iterators otherwise we'll spin up
-		// infinite next() calls by default and never start the event loop.
+		// infinite `next()` calls by default and never start the event loop.
 		(async () => {
 			for (let index = 0; index < concurrency; index++) {
 				try {

--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,11 @@ Returns a `Promise` that is fulfilled when all promises in `input` and ones retu
 
 #### input
 
-Type: `Iterable<Promise | unknown>`
+Type: `AsyncIterable<Promise<unknown> | unknown> | Iterable<Promise<unknown> | unknown>`
 
-Iterated over concurrently in the `mapper` function.
+Synchronous or asynchronous iterable that is iterated over concurrently, calling the `mapper` function for each element.  Each iterated item is `await`'d before the `mapper` is invoked so the iterable may return a `Promise` that resolves to an item.
+
+Asynchoronous iterables (distinguishing from iterables that return `Promise` that resolves to an item) can be used when the next item may not be ready without waiting for an asynchronous process to complete and/or the end of the iterable may be reached after the asynchornous proces completes (e.g. reading from a remote queue when the queue has reached empty, or reading lines from a stream).
 
 #### mapper(element, index)
 

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,9 @@ Returns a `Promise` that is fulfilled when all promises in `input` and ones retu
 
 Type: `AsyncIterable<Promise<unknown> | unknown> | Iterable<Promise<unknown> | unknown>`
 
-Synchronous or asynchronous iterable that is iterated over concurrently, calling the `mapper` function for each element.  Each iterated item is `await`'d before the `mapper` is invoked so the iterable may return a `Promise` that resolves to an item.
+Synchronous or asynchronous iterable that is iterated over concurrently, calling the `mapper` function for each element. Each iterated item is `await`'d before the `mapper` is invoked so the iterable may return a `Promise` that resolves to an item.
 
-Asynchoronous iterables (distinguishing from iterables that return `Promise` that resolves to an item) can be used when the next item may not be ready without waiting for an asynchronous process to complete and/or the end of the iterable may be reached after the asynchornous proces completes (e.g. reading from a remote queue when the queue has reached empty, or reading lines from a stream).
+Asynchronous iterables (different from synchronous iterables that return `Promise` that resolves to an item) can be used when the next item may not be ready without waiting for an asynchronous process to complete and/or the end of the iterable may be reached after the asynchronous process completes. For example, reading from a remote queue when the queue has reached empty, or reading lines from a stream.
 
 #### mapper(element, index)
 

--- a/test.js
+++ b/test.js
@@ -7,7 +7,9 @@ import AggregateError from 'aggregate-error';
 import pMap, {pMapSkip} from './index.js';
 
 const sharedInput = [
-	Promise.resolve([10, 300]),
+	[async () => {
+		return 10;
+	}, 300],
 	[20, 200],
 	[30, 100]
 ];
@@ -15,7 +17,9 @@ const sharedInput = [
 const errorInput1 = [
 	[20, 200],
 	[30, 100],
-	[() => Promise.reject(new Error('foo')), 10],
+	[async () => {
+		throw new Error('foo');
+	}, 10],
 	[() => {
 		throw new Error('bar');
 	}, 10]
@@ -23,7 +27,9 @@ const errorInput1 = [
 
 const errorInput2 = [
 	[20, 200],
-	[() => Promise.reject(new Error('bar')), 10],
+	[async () => {
+		throw new Error('bar');
+	}, 10],
 	[30, 100],
 	[() => {
 		throw new Error('foo');
@@ -152,10 +158,128 @@ test('pMapSkip', async t => {
 });
 
 test('do not run mapping after stop-on-error happened', async t => {
-	const input = [1, delay(300, {value: 2}), 3];
+	const input = [1, async () => delay(300, {value: 2}), 3];
 	const mappedValues = [];
 	await t.throwsAsync(
 		pMap(input, async value => {
+			value = typeof value === 'function' ? await value() : value;
+			mappedValues.push(value);
+			if (value === 1) {
+				await delay(100);
+				throw new Error('Oops!');
+			}
+		})
+	);
+	await delay(500);
+	t.deepEqual(mappedValues, [1, 3, 2]);
+});
+
+class AsyncTestData {
+	constructor(data) {
+		this.data = data;
+	}
+
+	async * [Symbol.asyncIterator]() {
+		for (let i = 0; i < this.data.length; i++) {
+			// Add a delay between each item iterated
+			// eslint-disable-next-line no-await-in-loop
+			await delay(10);
+			yield this.data[i];
+		}
+	}
+}
+
+//
+// Async Iterator tests
+//
+
+test('asyncIterator - main', async t => {
+	const end = timeSpan();
+	t.deepEqual(await pMap(new AsyncTestData(sharedInput), mapper), [10, 20, 30]);
+
+	// We give it some leeway on both sides of the expected 300ms as the exact value depends on the machine and workload.
+	t.true(inRange(end(), {start: 290, end: 430}));
+});
+
+test('asyncIterator - concurrency: 1', async t => {
+	const end = timeSpan();
+	t.deepEqual(await pMap(new AsyncTestData(sharedInput), mapper, {concurrency: 1}), [10, 20, 30]);
+	t.true(inRange(end(), {start: 590, end: 760}));
+});
+
+test('asyncIterator - concurrency: 4', async t => {
+	const concurrency = 4;
+	let running = 0;
+
+	await pMap(new AsyncTestData(Array.from({length: 100}).fill(0)), async () => {
+		running++;
+		t.true(running <= concurrency);
+		await delay(randomInt(30, 200));
+		running--;
+	}, {concurrency});
+});
+
+test('asyncIterator - handles empty iterable', async t => {
+	t.deepEqual(await pMap(new AsyncTestData([]), mapper), []);
+});
+
+test('asyncIterator - async with concurrency: 2 (random time sequence)', async t => {
+	const input = Array.from({length: 10}).map(() => randomInt(0, 100));
+	const mapper = value => delay(value, {value});
+	const result = await pMap(new AsyncTestData(input), mapper, {concurrency: 2});
+	t.deepEqual(result, input);
+});
+
+test('asyncIterator - async with concurrency: 2 (problematic time sequence)', async t => {
+	const input = [100, 200, 10, 36, 13, 45];
+	const mapper = value => delay(value, {value});
+	const result = await pMap(new AsyncTestData(input), mapper, {concurrency: 2});
+	t.deepEqual(result, input);
+});
+
+test('asyncIterator - async with concurrency: 2 (out of order time sequence)', async t => {
+	const input = [200, 100, 50];
+	const mapper = value => delay(value, {value});
+	const result = await pMap(new AsyncTestData(input), mapper, {concurrency: 2});
+	t.deepEqual(result, input);
+});
+
+test('asyncIterator - enforce number in options.concurrency', async t => {
+	await t.throwsAsync(pMap(new AsyncTestData([]), () => {}, {concurrency: 0}), {instanceOf: TypeError});
+	await t.throwsAsync(pMap(new AsyncTestData([]), () => {}, {concurrency: 1.5}), {instanceOf: TypeError});
+	await t.notThrowsAsync(pMap(new AsyncTestData([]), () => {}, {concurrency: 1}));
+	await t.notThrowsAsync(pMap(new AsyncTestData([]), () => {}, {concurrency: 10}));
+	await t.notThrowsAsync(pMap(new AsyncTestData([]), () => {}, {concurrency: Number.POSITIVE_INFINITY}));
+});
+
+test('asyncIterator - immediately rejects when stopOnError is true', async t => {
+	await t.throwsAsync(pMap(new AsyncTestData(errorInput1), mapper, {concurrency: 1}), {message: 'foo'});
+	await t.throwsAsync(pMap(new AsyncTestData(errorInput2), mapper, {concurrency: 1}), {message: 'bar'});
+});
+
+test('asyncIterator - aggregate errors when stopOnError is false', async t => {
+	await t.notThrowsAsync(pMap(new AsyncTestData(sharedInput), mapper, {concurrency: 1, stopOnError: false}));
+	await t.throwsAsync(pMap(new AsyncTestData(errorInput1), mapper, {concurrency: 1, stopOnError: false}), {instanceOf: AggregateError, message: /foo(.|\n)*bar/});
+	await t.throwsAsync(pMap(new AsyncTestData(errorInput2), mapper, {concurrency: 1, stopOnError: false}), {instanceOf: AggregateError, message: /bar(.|\n)*foo/});
+});
+
+test('asyncIterator - pMapSkip', async t => {
+	t.deepEqual(await pMap(new AsyncTestData([
+		1,
+		pMapSkip,
+		2
+	]), async value => value), [1, 2]);
+});
+
+test('asyncIterator - do not run mapping after stop-on-error happened', async t => {
+	const input = [1, async () => delay(300, {value: 2}), 3];
+	const mappedValues = [];
+	await t.throwsAsync(
+		pMap(new AsyncTestData(input), async value => {
+			if (typeof value === 'function') {
+				value = await value();
+			}
+
 			mappedValues.push(value);
 			if (value === 1) {
 				await delay(100);

--- a/test.js
+++ b/test.js
@@ -7,9 +7,7 @@ import AggregateError from 'aggregate-error';
 import pMap, {pMapSkip} from './index.js';
 
 const sharedInput = [
-	[async () => {
-		return 10;
-	}, 300],
+	[async () => 10, 300],
 	[20, 200],
 	[30, 100]
 ];
@@ -180,11 +178,11 @@ class AsyncTestData {
 	}
 
 	async * [Symbol.asyncIterator]() {
-		for (let i = 0; i < this.data.length; i++) {
-			// Add a delay between each item iterated
+		for (let index = 0; index < this.data.length; index++) {
+			// Add a delay between each iterated item
 			// eslint-disable-next-line no-await-in-loop
 			await delay(10);
-			yield this.data[i];
+			yield this.data[index];
 		}
 	}
 }
@@ -367,4 +365,16 @@ test('asyncIterator - get the correct exception after stop-on-error', async t =>
 	await delay(500);
 	await t.throwsAsync(task, {message: 'Oops! 1'});
 	t.deepEqual(mappedValues, [1, 2, 3]);
+});
+
+test('incorrect input type', async t => {
+	let mapperCalled = false;
+
+	const task = pMap(123456, async () => {
+		mapperCalled = true;
+		await delay(100);
+	});
+	await delay(500);
+	await t.throwsAsync(task, {message: 'Expected `input` to be either an `Iterable` or `AsyncIterable`, got (number)'});
+	t.false(mapperCalled);
 });


### PR DESCRIPTION
# Overview
- Expand capabilities to handle both async and sync iterables - Fixes #20 

# Open Issues
- [x] Duplicating the tests for the async versions doesn't feel right - Let me know if there is a better way to handle this with `ava`
- [x] There is a problem in the original functionality around the `stop-on-error` test that needs to be resolved
  - The test has a bug in that neither p-map nor the test mapper function, which is provided for that specific test and is not the common version, await the calling of the delay() function for item 2
  - This means that item 2 will only ever return a Promise, never a value
  - When this is fixed to await the function call, it causes the returned results to change from `[1, 3]` to `[1, 3, 2]`
  - Fixing this test makes it clear that the `concurrency setup` loop does not wait for mappers, so the only way to make this test fail would be to have enough items that eventually the initial iteration could not reach the last items in the test array before the 100 ms delay on the exception expires
  - With `concurrency = 1` this test behaves as expected since there are not unlimited unawaited promises created
  - Let me know your thoughts on how to resolve this as it becomes more apparent with the behavior changes needed for asyncIterable (where the concurrency setup iteration of asyncIterable has to be awaited to prevent inifinte runners from being created)
  - The test, in the state it's in in this PR, does not actually demonstrate that stop on error works as intended