### PR TITLE
Prevent some potential unhandled exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,10 +106,9 @@ export default async function pMap(
 			try {
 				next();
 			} catch (error) {
-				if (!isRejected) {
-					isRejected = true;
-					reject(error);
-				}
+				isRejected = true;
+				reject(error);
+				break;
 			}
 
 			if (isIterableDone || isRejected) {

--- a/index.js
+++ b/index.js
@@ -87,10 +87,8 @@ export default async function pMap(
 						try {
 							next();
 						} catch (error) {
-							if (!isRejected) {
-								isRejected = true;
-								reject(error);
-							}
+							isRejected = true;
+							reject(error);
 						}
 					}
 				}

--- a/test.js
+++ b/test.js
@@ -40,6 +40,30 @@ const mapper = async ([value, ms]) => {
 	return value;
 };
 
+class ThrowingIterator {
+	constructor(max, throwOnIndex) {
+		this._max = max;
+		this._throwOnIndex = throwOnIndex;
+	}
+
+	[Symbol.iterator]() {
+		let index = 0;
+		const max = this._max;
+		const throwOnIndex = this._throwOnIndex;
+		return {
+			next() {
+				if (index === throwOnIndex) {
+					throw new Error(`throwing on index ${index}`);
+				}
+
+				const item = {value: index, done: index === max};
+				index++;
+				return item;
+			}
+		};
+	}
+}
+
 test('main', async t => {
 	const end = timeSpan();
 	t.deepEqual(await pMap(sharedInput, mapper), [10, 20, 30]);
@@ -128,8 +152,62 @@ test('do not run mapping after stop-on-error happened', async t => {
 				await delay(100);
 				throw new Error('Oops!');
 			}
-		})
+		},
+		{concurrency: 1})
 	);
 	await delay(500);
-	t.deepEqual(mappedValues, [1, 3]);
+	t.deepEqual(mappedValues, [1]);
+});
+
+test('catches exception from source iterator - 1st item', async t => {
+	const input = new ThrowingIterator(100, 0);
+	const mappedValues = [];
+	await t.throwsAsync(pMap(
+		input,
+		async value => {
+			mappedValues.push(value);
+			await delay(100);
+			return value;
+		},
+		{concurrency: 1}
+	));
+	await delay(300);
+	t.deepEqual(mappedValues, []);
+});
+
+// The 2nd iterable item throwing is distinct from the 1st when concurrency is 1 because
+// it means that the source next() is invoked from next() and not from
+// the constructor
+test('catches exception from source iterator - 2nd item', async t => {
+	const input = new ThrowingIterator(100, 1);
+	const mappedValues = [];
+	await t.throwsAsync(pMap(
+		input,
+		async value => {
+			mappedValues.push(value);
+			await delay(100);
+			return value;
+		},
+		{concurrency: 1}
+	));
+	await delay(300);
+	t.deepEqual(mappedValues, [0]);
+});
+
+// The 2nd iterable item throwing after a 1st item mapper exception, with stopOnError false,
+// is distinct from other cases because our next() is called from a catch block
+test('catches exception from source iterator - 2nd item after 1st item mapper throw', async t => {
+	const input = new ThrowingIterator(100, 1);
+	const mappedValues = [];
+	await t.throwsAsync(pMap(
+		input,
+		async value => {
+			mappedValues.push(value);
+			await delay(100);
+			throw new Error('mapper threw error');
+		},
+		{concurrency: 1, stopOnError: false}
+	));
+	await delay(300);
+	t.deepEqual(mappedValues, [0]);
 });

--- a/test.js
+++ b/test.js
@@ -45,15 +45,15 @@ class ThrowingIterator {
 		this._max = max;
 		this._throwOnIndex = throwOnIndex;
 		this.index = 0;
+		this[Symbol.iterator] = this[Symbol.iterator].bind(this);
 	}
 
 	[Symbol.iterator]() {
 		let index = 0;
 		const max = this._max;
 		const throwOnIndex = this._throwOnIndex;
-		const obj = this;
 		return {
-			next() {
+			next: (() => {
 				try {
 					if (index === throwOnIndex) {
 						throw new Error(`throwing on index ${index}`);
@@ -63,9 +63,12 @@ class ThrowingIterator {
 					return item;
 				} finally {
 					index++;
-					obj.index = index;
+					this.index = index;
 				}
-			}
+			// eslint is wrong - bind is needed else the next() call cannot update
+			// this.index, which we need to track how many times the iterator was called
+			// eslint-disable-next-line no-extra-bind
+			}).bind(this)
 		};
 	}
 }


### PR DESCRIPTION
- Source iterator next() functions can throw
- There are 3 distinct cases where next() is called, one of which does not have a try/catch around it that will reject the outer promise, resulting in an unhandled promise rejection
- Note: in the current state, the 3rd test fails - I'm not sure how you want to handle this... a try/catch for the entire next() function would handle it... but there are other ways, such as a try/catch within the catch...