### PR TITLE
Add test cases for multiple mapper errors with stop on error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface Options {
 
 	/**
 	When set to `true`, the first mapper rejection will be rejected back to the consumer. Caveat: any already-started async mappers will continue to run until they resolve or reject. In the case of infinite concurrency with sync iterables *all* mappers are invoked on startup and will continue after the first rejection. [Issue #51](issues/51) can be implemented for abort control.
-	
+
 	When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
 
 	@default true

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ export interface Options {
 	readonly concurrency?: number;
 
 	/**
+	When set to `true`, the first mapper rejection will be rejected back to the consumer. Caveat: any already-started async mappers will continue to run until they resolve or reject. In the case of infinite concurrency with sync iterables *all* mappers are invoked on startup and will continue after the first rejection. [Issue #51](issues/51) can be implemented for abort control.
+	
 	When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
 
 	@default true

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,8 @@ Number of concurrently pending promises returned by `mapper`.
 Type: `boolean`\
 Default: `true`
 
+When set to `true`, the first mapper rejection will be rejected back to the consumer.  Caveat: any already-started async mappers will continue to run until they resolve or reject but they cannot be awaited as their promises are not exposed; in the case of infinite concurrency with sync iterables *all* mappers will be started on startup and will continue after a rejection.  [Issue #51](issues/51) can be implemented to address additional exception and abort use cases.
+
 When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
 
 ### pMapSkip

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Number of concurrently pending promises returned by `mapper`.
 Type: `boolean`\
 Default: `true`
 
-When set to `true`, the first mapper rejection will be rejected back to the consumer.  Caveat: any already-started async mappers will continue to run until they resolve or reject but they cannot be awaited as their promises are not exposed; in the case of infinite concurrency with sync iterables *all* mappers will be started on startup and will continue after a rejection.  [Issue #51](issues/51) can be implemented to address additional exception and abort use cases.
+When set to `true`, the first mapper rejection will be rejected back to the consumer. Caveat: any already-started async mappers will continue to run until they resolve or reject. In the case of infinite concurrency with sync iterables *all* mappers are invoked on startup and will continue after the first rejection. [Issue #51](issues/51) can be implemented for abort control.
 
 When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
 

--- a/test.js
+++ b/test.js
@@ -409,4 +409,3 @@ test('no unhandled rejected promises from mapper throws - concurrency 1', async 
 	);
 	t.deepEqual(mappedValues, [1]);
 });
-

--- a/test.js
+++ b/test.js
@@ -389,7 +389,7 @@ test('no unhandled rejected promises from mapper throws - infinite concurrency',
 		}),
 		{message: 'Oops! 1'}
 	);
-	// Note: all 3 mappers get invoked, all 3 throw, even with stop on error this
+	// Note: All 3 mappers get invoked, all 3 throw, even with stop on error this
 	// should raise an AggregateError with all 3 exceptions instead of throwing 1
 	// exception and hiding the other 2.
 	t.deepEqual(mappedValues, [1, 2, 3]);

--- a/test.js
+++ b/test.js
@@ -389,7 +389,7 @@ test('no unhandled rejected promises from mapper throws - infinite concurrency',
 		}),
 		{message: 'Oops! 1'}
 	);
-	// Note: All 3 mappers get invoked, all 3 throw, even with stop on error this
+	// Note: All 3 mappers get invoked, all 3 throw, even with `{stopOnError: true}` this
 	// should raise an AggregateError with all 3 exceptions instead of throwing 1
 	// exception and hiding the other 2.
 	t.deepEqual(mappedValues, [1, 2, 3]);

--- a/test.js
+++ b/test.js
@@ -387,7 +387,7 @@ test('no unhandled rejected promises from mapper throws - infinite concurrency',
 			await delay(100);
 			throw new Error(`Oops! ${value}`);
 		}),
-		{message: 'Some big AggregateError message'}
+		{message: 'Oops! 1'}
 	);
 	// Note: all 3 mappers get invoked, all 3 throw, even with stop on error this
 	// should raise an AggregateError with all 3 exceptions instead of throwing 1


### PR DESCRIPTION
- Add test cases that demonstrate a single exception being rejected when all mappers fail and stop on error is set