### PR TITLE
Add support for multiple `pMapSkip`'s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 yarn.lock
-.history

--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ export default async function pMap(
 					} else {
 						isResolved = true;
 
+						// Delete skipped index from back to front, to support multiple pMapSkips
+						// so use the unshift method when putting index into skippedIndexes.
+						// see line 93
 						for (const skippedIndex of skippedIndexes) {
 							result.splice(skippedIndex, 1);
 						}
@@ -87,7 +90,7 @@ export default async function pMap(
 					const value = await mapper(element, index);
 
 					if (value === pMapSkip) {
-						skippedIndexes.push(index);
+						skippedIndexes.unshift(index);
 					} else {
 						result[index] = value;
 					}

--- a/index.js
+++ b/index.js
@@ -72,13 +72,12 @@ export default async function pMap(
 					const pureResult = [];
 
 					// Support multiple pMapSkips
-					const resultIterator = result.keys();
-					for (const index of resultIterator) {
+					for (const [index, value] of result.entries()) {
 						if (skippedIndexesMap.get(index) === pMapSkip) {
 							continue;
 						}
 
-						pureResult.push(result[index]);
+						pureResult.push(value);
 					}
 
 					resolve(pureResult);

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ export default async function pMap(
 
 					const pureResult = [];
 
-					// Support multiple pMapSkips
+					// Support multiple `pMapSkip`'s.
 					for (const [index, value] of result.entries()) {
 						if (skippedIndexesMap.get(index) === pMapSkip) {
 							continue;

--- a/index.js
+++ b/index.js
@@ -72,8 +72,8 @@ export default async function pMap(
 					const pureResult = [];
 
 					// Support multiple pMapSkips
-					// eslint-disable-next-line unicorn/no-for-loop
-					for (let index = 0; index < result.length; index++) {
+					const resultIterator = result.keys();
+					for (const index of resultIterator) {
 						if (skippedIndexesMap.get(index) === pMapSkip) {
 							continue;
 						}

--- a/test-multiple-pmapskips-performance.js
+++ b/test-multiple-pmapskips-performance.js
@@ -1,0 +1,37 @@
+import test from 'ava';
+import inRange from 'in-range';
+import timeSpan from 'time-span';
+import pMap, {pMapSkip} from './index.js';
+
+function generateSkipPerformanceData(length) {
+	const data = [];
+	for (let index = 0; index < length; index++) {
+		data.push(pMapSkip);
+	}
+
+	return data;
+}
+
+test('multiple pMapSkips - algorithmic complexity', async t => {
+	const testData = [generateSkipPerformanceData(1000), generateSkipPerformanceData(10000), generateSkipPerformanceData(100000)];
+	const testDurationsMS = [];
+
+	for (const data of testData) {
+		const end = timeSpan();
+		// eslint-disable-next-line no-await-in-loop
+		await pMap(data, async value => value);
+		testDurationsMS.push(end());
+	}
+
+	for (let index = 0; index < testDurationsMS.length - 1; index++) {
+		// Time for 10x more items should take between 9x and 11x more time
+		const smallerDuration = testDurationsMS[index];
+		const longerDuration = testDurationsMS[index + 1];
+
+		// The longer test needs to be a little longer and also not 10x more than the
+		// shorter test.  This is not perfect... there is some fluctuation.
+		// The idea here is to catch a regression that makes pMapSkip handling O(n^2)
+		// on the number of pMapSkip items in the input
+		t.true(inRange(longerDuration, {start: 1.2 * smallerDuration, end: 15 * smallerDuration}));
+	}
+});

--- a/test-multiple-pmapskips-performance.js
+++ b/test-multiple-pmapskips-performance.js
@@ -24,14 +24,14 @@ test('multiple pMapSkips - algorithmic complexity', async t => {
 	}
 
 	for (let index = 0; index < testDurationsMS.length - 1; index++) {
-		// Time for 10x more items should take between 9x and 11x more time
+		// Time for 10x more items should take between 9x and 11x more time.
 		const smallerDuration = testDurationsMS[index];
 		const longerDuration = testDurationsMS[index + 1];
 
 		// The longer test needs to be a little longer and also not 10x more than the
-		// shorter test.  This is not perfect... there is some fluctuation.
-		// The idea here is to catch a regression that makes pMapSkip handling O(n^2)
-		// on the number of pMapSkip items in the input
+		// shorter test. This is not perfect... there is some fluctuation.
+		// The idea here is to catch a regression that makes `pMapSkip` handling O(n^2)
+		// on the number of `pMapSkip` items in the input.
 		t.true(inRange(longerDuration, {start: 1.2 * smallerDuration, end: 15 * smallerDuration}));
 	}
 });

--- a/test.js
+++ b/test.js
@@ -155,6 +155,19 @@ test('pMapSkip', async t => {
 	], async value => value), [1, 2]);
 });
 
+test('multiple pMapSkips', async t => {
+	t.deepEqual(await pMap([
+		1,
+		pMapSkip,
+		2,
+		pMapSkip,
+		3,
+		pMapSkip,
+		pMapSkip,
+		4
+	], async value => value), [1, 2, 3, 4]);
+});
+
 test('all mappers should run when concurrency is infinite, even after stop-on-error happened', async t => {
 	const input = [1, async () => delay(300, {value: 2}), 3];
 	const mappedValues = [];
@@ -267,6 +280,19 @@ test('asyncIterator - pMapSkip', async t => {
 		pMapSkip,
 		2
 	]), async value => value), [1, 2]);
+});
+
+test('asyncIterator - multiple pMapSkips', async t => {
+	t.deepEqual(await pMap(new AsyncTestData([
+		1,
+		pMapSkip,
+		2,
+		pMapSkip,
+		3,
+		pMapSkip,
+		pMapSkip,
+		4
+	]), async value => value), [1, 2, 3, 4]);
 });
 
 test('asyncIterator - all mappers should run when concurrency is infinite, even after stop-on-error happened', async t => {

--- a/test.js
+++ b/test.js
@@ -168,6 +168,15 @@ test('multiple pMapSkips', async t => {
 	], async value => value), [1, 2, 3, 4]);
 });
 
+test('all pMapSkips', async t => {
+	t.deepEqual(await pMap([
+		pMapSkip,
+		pMapSkip,
+		pMapSkip,
+		pMapSkip
+	], async value => value), []);
+});
+
 test('all mappers should run when concurrency is infinite, even after stop-on-error happened', async t => {
 	const input = [1, async () => delay(300, {value: 2}), 3];
 	const mappedValues = [];
@@ -293,6 +302,15 @@ test('asyncIterator - multiple pMapSkips', async t => {
 		pMapSkip,
 		4
 	]), async value => value), [1, 2, 3, 4]);
+});
+
+test('asyncIterator - all pMapSkips', async t => {
+	t.deepEqual(await pMap(new AsyncTestData([
+		pMapSkip,
+		pMapSkip,
+		pMapSkip,
+		pMapSkip
+	]), async value => value), []);
 });
 
 test('asyncIterator - all mappers should run when concurrency is infinite, even after stop-on-error happened', async t => {


### PR DESCRIPTION
like this:
```javascript
console.log(await pMap([1, pMapSkip, 2, pMapSkip, 3], async value => value)) // [1, 2, 3]
```