### PR TITLE
Add `pMapIterable`

### DIFF
--- a/assert-in-range.js
+++ b/assert-in-range.js
@@ -1,0 +1,10 @@
+import chalk from 'chalk';
+import inRange from 'in-range';
+
+export default function assertInRange(t, value, {start = 0, end}) {
+	if (inRange(value, {start, end})) {
+		t.pass();
+	} else {
+		t.fail(`${start} ${start <= value ? '≤' : chalk.red('≰')} ${chalk.yellow(value)} ${value <= end ? '≤' : chalk.red('≰')} ${end}`);
+	}
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ type BaseOptions = {
 	@default Infinity
 	*/
 	readonly concurrency?: number;
-}
+};
 
 export type Options = BaseOptions & {
 	/**
@@ -51,7 +51,7 @@ export type IterableOptions = BaseOptions & {
 	@default concurrency
 	*/
 	readonly backpressure?: number;
-}
+};
 
 type MaybePromise<T> = T | Promise<T>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,7 +111,7 @@ export default function pMap<Element, NewElement>(
 import {pMapIterable} from 'p-map';
 
 // Multiple posts are fetched concurrently, with limited concurrency and backpressure
-for await (const post of pMapIterable(postIds, getPostMetadata)) {
+for await (const post of pMapIterable(postIds, getPostMetadata, {concurrency: 8})) {
 	console.log(post);
 };
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,8 @@ export type IterableOptions = BaseOptions & {
 	/**
 	Maximum number of promises returned by `mapper` that have resolved but not yet collected by the consumer of the async iterable. Calls to `mapper` will be limited so that there is never too much backpressure.
 
+	Useful whenever you are consuming the iterable slower than what the mapper function can produce concurrently. For example, to avoid making an overwhelming number of HTTP requests if you are saving each of the results to a database.
+
 	Default: `options.concurrency`
 	*/
 	readonly backpressure?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export interface Options {
+interface BaseOptions {
 	/**
 	Number of concurrently pending promises returned by `mapper`.
 
@@ -7,7 +7,9 @@ export interface Options {
 	@default Infinity
 	*/
 	readonly concurrency?: number;
+}
 
+export interface Options extends BaseOptions {
 	/**
 	When `true`, the first mapper rejection will be rejected back to the consumer.
 
@@ -42,6 +44,15 @@ export interface Options {
 	```
 	*/
 	readonly signal?: AbortSignal;
+}
+
+export interface IterableOptions {
+	/**
+	Maximum number of promises returned by `mapper` that have resolved but not yet collected by the consumer of the async iterable. Calls to `mapper` will be limited so that there is never too much backpressure.
+
+	@default concurrency
+	*/
+	readonly backpressure?: number;
 }
 
 type MaybePromise<T> = T | Promise<T>;
@@ -89,6 +100,27 @@ export default function pMap<Element, NewElement>(
 	mapper: Mapper<Element, NewElement>,
 	options?: Options
 ): Promise<Array<Exclude<NewElement, typeof pMapSkip>>>;
+
+/**
+@param input - Synchronous or asynchronous iterable that is iterated over concurrently, calling the `mapper` function for each element. Each iterated item is `await`'d before the `mapper` is invoked so the iterable may return a `Promise` that resolves to an item. Asynchronous iterables (different from synchronous iterables that return `Promise` that resolves to an item) can be used when the next item may not be ready without waiting for an asynchronous process to complete and/or the end of the iterable may be reached after the asynchronous process completes. For example, reading from a remote queue when the queue has reached empty, or reading lines from a stream.
+@param mapper - Function which is called for every item in `input`. Expected to return a `Promise` or value.
+@returns An async iterable that streams each return value from `mapper` in order.
+
+@example
+```
+import {pMapIterable} from 'p-map';
+
+// Multiple posts are fetched concurrently, with limited concurrency and backpressure
+for await (const post of pMapIterable(postIds, getPostMetadata)) {
+	console.log(post);
+};
+```
+*/
+export default function pMapIterable<Element, NewElement>(
+	input: AsyncIterable<Element | Promise<Element>> | Iterable<Element | Promise<Element>>,
+	mapper: Mapper<Element, NewElement>,
+	options?: IterableOptions
+): AsyncIterable<Exclude<NewElement, typeof pMapSkip>>;
 
 /**
 Return this value from a `mapper` function to skip including the value in the returned array.

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,7 +114,7 @@ for await (const post of pMapIterable(postIds, getPostMetadata)) {
 };
 ```
 */
-export default function pMapIterable<Element, NewElement>(
+export function pMapIterable<Element, NewElement>(
 	input: AsyncIterable<Element | Promise<Element>> | Iterable<Element | Promise<Element>>,
 	mapper: Mapper<Element, NewElement>,
 	options?: IterableOptions

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ export type IterableOptions = BaseOptions & {
 	/**
 	Maximum number of promises returned by `mapper` that have resolved but not yet collected by the consumer of the async iterable. Calls to `mapper` will be limited so that there is never too much backpressure.
 
-	@default concurrency
+	Default: `options.concurrency`
 	*/
 	readonly backpressure?: number;
 };

--- a/index.js
+++ b/index.js
@@ -255,6 +255,7 @@ export function pMapIterable(
 							isDone = true;
 							waitingQueue[pendingQueue.length] = {done: true};
 							tryToFlushWaitingQueue();
+
 							return;
 						}
 
@@ -275,9 +276,12 @@ export function pMapIterable(
 							} catch (error) {
 								const index = pendingQueue.indexOf(promise);
 
-								pendingQueue.splice(index, 1);
+								pendingQueue.splice(index);
 
 								waitingQueue[index] = {error};
+
+								isDone = true;
+								waitingQueue[index + 1] = {done: true};
 							} finally {
 								tryToFlushWaitingQueue();
 							}
@@ -286,6 +290,10 @@ export function pMapIterable(
 						pendingQueue.push(promise);
 					} catch (error) {
 						waitingQueue[pendingQueue.length] = {error};
+
+						isDone = true;
+						waitingQueue[pendingQueue.length + 1] = {done: true};
+
 						tryToFlushWaitingQueue();
 					}
 				}

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ export function pMapIterable(
 	mapper,
 	{
 		concurrency = Number.POSITIVE_INFINITY,
-		backpressure,
+		backpressure = concurrency,
 	} = {},
 ) {
 	if (iterable[Symbol.iterator] === undefined && iterable[Symbol.asyncIterator] === undefined) {

--- a/index.js
+++ b/index.js
@@ -48,8 +48,6 @@ export default async function pMap(
 			throw new TypeError('Mapper function is required');
 		}
 
-
-
 		if (!((Number.isSafeInteger(concurrency) && concurrency >= 1) || concurrency === Number.POSITIVE_INFINITY)) {
 			throw new TypeError(`Expected \`concurrency\` to be an integer from 1 and up or \`Infinity\`, got \`${concurrency}\` (${typeof concurrency})`);
 		}
@@ -223,10 +221,10 @@ export function pMapIterable(
 	return {
 		[Symbol.asyncIterator]() {
 			let isDone = false;
-			let pendingQueue = [];
-			let waitingQueue = [];
-			let valueQueue = [];
-			let valuePromises = [];
+			const pendingQueue = [];
+			const waitingQueue = [];
+			const valueQueue = [];
+			const valuePromises = [];
 
 			const iterator = typeof iterable[Symbol.asyncIterator] === 'undefined' ? iterable[Symbol.iterator]() : iterable[Symbol.asyncIterator]();
 
@@ -276,7 +274,7 @@ export function pMapIterable(
 								}
 							}
 						}
-					})()
+					})();
 
 					pendingQueue.push(promise);
 				}
@@ -304,11 +302,11 @@ export function pMapIterable(
 
 					return new Promise((resolve, reject) => {
 						valuePromises.push({resolve, reject});
-					})
-				}
-			}
+					});
+				},
+			};
 		},
-	}
+	};
 }
 
 export const pMapSkip = Symbol('skip');

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ export function pMapIterable(
 			const valueQueue = [];
 			const valuePromises = [];
 
-			const iterator = typeof iterable[Symbol.asyncIterator] === 'undefined' ? iterable[Symbol.iterator]() : iterable[Symbol.asyncIterator]();
+			const iterator = iterable[Symbol.asyncIterator] === undefined ? iterable[Symbol.iterator]() : iterable[Symbol.asyncIterator]();
 
 			function tryToContinue() {
 				while (pendingQueue.length < concurrency && valueQueue.length + waitingQueue.length + pendingQueue.length < backpressure && !isDone) {

--- a/index.js
+++ b/index.js
@@ -319,6 +319,11 @@ export function pMapIterable(
 						valuePromises.push({resolve, reject});
 					});
 				},
+				async return() {
+					isDone = true;
+
+					return {done: true};
+				},
 			};
 		},
 	};

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectAssignable} from 'tsd';
-import pMap, {type Options, type Mapper, pMapSkip} from './index.js';
+import pMap, {pMapIterable, type Options, type Mapper, pMapSkip} from './index.js';
 
 const sites = [
 	'https://sindresorhus.com',
@@ -48,3 +48,5 @@ expectType<Promise<number[]>>(pMap(numbers, (number: number) => {
 
 	return pMapSkip;
 }));
+
+expectType<AsyncIterable<string>>(pMapIterable(sites, asyncMapper));

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"aggregate-error": "^4.0.0"
+		"aggregate-error": "^4.0.0",
+		"deferred-async-iterator": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 	],
 	"devDependencies": {
 		"ava": "^5.2.0",
+		"chalk": "^5.3.0",
 		"delay": "^5.0.0",
 		"in-range": "^3.0.0",
 		"random-int": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"aggregate-error": "^4.0.0",
-		"deferred-async-iterator": "^3.0.0"
+		"aggregate-error": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^4.1.0",

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,19 @@ console.log(result);
 
 Returns a `Promise` that is fulfilled when all promises in `input` and ones returned from `mapper` are fulfilled, or rejects if any of the promises reject. The fulfilled value is an `Array` of the fulfilled values returned from `mapper` in `input` order.
 
+### pMapIterable(input, mapper, options?)
+
+Returns an async iterable that streams each return value from `mapper` in order.
+
+```js
+import {pMapIterable} from 'p-map';
+
+// Multiple posts are fetched concurrently, with limited concurrency and backpressure
+for await (const post of pMapIterable(postIds, getPostMetadata)) {
+	console.log(post);
+};
+```
+
 #### input
 
 Type: `AsyncIterable<Promise<unknown> | unknown> | Iterable<Promise<unknown> | unknown>`
@@ -67,7 +80,19 @@ Minimum: `1`
 
 Number of concurrently pending promises returned by `mapper`.
 
+##### backpressure
+
+**Only for `pMapInterable`**
+
+Type: `number` *(Integer)*\
+Default: `concurrency`\
+Minimum: `concurrency`
+
+Maximum number of promises returned by `mapper` that have resolved but not yet collected by the consumer of the async iterable. Calls to `mapper` will be limited so that there is never too much backpressure.
+
 ##### stopOnError
+
+**Only for `pMap`**
 
 Type: `boolean`\
 Default: `true`
@@ -79,6 +104,8 @@ When `false`, instead of stopping when a promise rejects, it will wait for all t
 Caveat: When `true`, any already-started async mappers will continue to run until they resolve or reject. In the case of infinite concurrency with sync iterables, *all* mappers are invoked on startup and will continue after the first rejection. [Issue #51](https://github.com/sindresorhus/p-map/issues/51) can be implemented for abort control.
 
 ##### signal
+
+**Only for `pMap`**
 
 Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,8 @@ Minimum: `options.concurrency`
 
 Maximum number of promises returned by `mapper` that have resolved but not yet collected by the consumer of the async iterable. Calls to `mapper` will be limited so that there is never too much backpressure.
 
+Useful whenever you are consuming the iterable slower than what the mapper function can produce concurrently. For example, to avoid making an overwhelming number of HTTP requests if you are saving each of the results to a database.
+
 ##### stopOnError
 
 **Only for `pMap`**

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Returns an async iterable that streams each return value from `mapper` in order.
 import {pMapIterable} from 'p-map';
 
 // Multiple posts are fetched concurrently, with limited concurrency and backpressure
-for await (const post of pMapIterable(postIds, getPostMetadata)) {
+for await (const post of pMapIterable(postIds, getPostMetadata, {concurrency: 8})) {
 	console.log(post);
 };
 ```

--- a/readme.md
+++ b/readme.md
@@ -85,8 +85,8 @@ Number of concurrently pending promises returned by `mapper`.
 **Only for `pMapInterable`**
 
 Type: `number` *(Integer)*\
-Default: `concurrency`\
-Minimum: `concurrency`
+Default: `options.concurrency`\
+Minimum: `options.concurrency`
 
 Maximum number of promises returned by `mapper` that have resolved but not yet collected by the consumer of the async iterable. Calls to `mapper` will be limited so that there is never too much backpressure.
 

--- a/test-multiple-pmapskips-performance.js
+++ b/test-multiple-pmapskips-performance.js
@@ -1,6 +1,6 @@
 import test from 'ava';
-import inRange from 'in-range';
 import timeSpan from 'time-span';
+import assertInRange from './assert-in-range.js';
 import pMap, {pMapSkip} from './index.js';
 
 function generateSkipPerformanceData(length) {
@@ -32,6 +32,6 @@ test('multiple pMapSkips - algorithmic complexity', async t => {
 		// shorter test. This is not perfect... there is some fluctuation.
 		// The idea here is to catch a regression that makes `pMapSkip` handling O(n^2)
 		// on the number of `pMapSkip` items in the input.
-		t.true(inRange(longerDuration, {start: 1.2 * smallerDuration, end: 15 * smallerDuration}));
+		assertInRange(t, longerDuration, {start: 1.2 * smallerDuration, end: 15 * smallerDuration});
 	}
 });

--- a/test.js
+++ b/test.js
@@ -563,12 +563,20 @@ test('pMapIterable - stop on error', async t => {
 	t.deepEqual(output, [20]);
 });
 
-test('pMapIterable - concurrency', async t => {
+test('pMapIterable - concurrency: 1', async t => {
 	const end = timeSpan();
 	t.deepEqual(await collectAsyncIterable(pMapIterable(sharedInput, mapper, {concurrency: 1})), [10, 20, 30]);
 
 	// It could've only taken this much time if each were run in series
 	assertInRange(t, end(), {start: 590, end: 760});
+});
+
+test('pMapIterable - concurrency: 2', async t => {
+	const end = timeSpan();
+
+	t.deepEqual(await collectAsyncIterable(pMapIterable(longerSharedInput, mapper, {concurrency: 2})), [10, 20, 30, 40, 50]);
+
+	assertInRange(t, end(), {start: 325, end: 375});
 });
 
 test('pMapIterable - backpressure', async t => {

--- a/test.js
+++ b/test.js
@@ -499,3 +499,7 @@ async function collectAsyncIterable(asyncIterable) {
 test('pMapIterable', async t => {
 	t.deepEqual(await collectAsyncIterable(pMapIterable(sharedInput, mapper)), [10, 20, 30]);
 });
+
+test('pMapIterable - empty', async t => {
+	t.deepEqual(await collectAsyncIterable(pMapIterable([], mapper)), []);
+});

--- a/test.js
+++ b/test.js
@@ -76,9 +76,9 @@ class ThrowingIterator {
 					index++;
 					this.index = index;
 				}
-				// eslint is wrong - bind is needed else the next() call cannot update
-				// this.index, which we need to track how many times the iterator was called
-				// eslint-disable-next-line no-extra-bind
+			// eslint is wrong - bind is needed else the next() call cannot update
+			// this.index, which we need to track how many times the iterator was called
+			// eslint-disable-next-line no-extra-bind
 			}).bind(this),
 		};
 	}

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import inRange from 'in-range';
 import timeSpan from 'time-span';
 import randomInt from 'random-int';
 import AggregateError from 'aggregate-error';
-import pMap, {pMapSkip} from './index.js';
+import pMap, {pMapIterable, pMapSkip} from './index.js';
 
 const sharedInput = [
 	[async () => 10, 300],
@@ -69,9 +69,9 @@ class ThrowingIterator {
 					index++;
 					this.index = index;
 				}
-			// eslint is wrong - bind is needed else the next() call cannot update
-			// this.index, which we need to track how many times the iterator was called
-			// eslint-disable-next-line no-extra-bind
+				// eslint is wrong - bind is needed else the next() call cannot update
+				// this.index, which we need to track how many times the iterator was called
+				// eslint-disable-next-line no-extra-bind
 			}).bind(this),
 		};
 	}
@@ -486,3 +486,17 @@ if (globalThis.AbortController !== undefined) {
 		});
 	});
 }
+
+async function collectAsyncIterable(asyncIterable) {
+	const values = [];
+
+	for await (const value of asyncIterable) {
+		values.push(value);
+	}
+
+	return values;
+}
+
+test('pMapIterable', async t => {
+	t.deepEqual(await collectAsyncIterable(pMapIterable(sharedInput, mapper)), [10, 20, 30]);
+});

--- a/test.js
+++ b/test.js
@@ -69,9 +69,9 @@ class ThrowingIterator {
 					index++;
 					this.index = index;
 				}
-				// eslint is wrong - bind is needed else the next() call cannot update
-				// this.index, which we need to track how many times the iterator was called
-				// eslint-disable-next-line no-extra-bind
+			// eslint is wrong - bind is needed else the next() call cannot update
+			// this.index, which we need to track how many times the iterator was called
+			// eslint-disable-next-line no-extra-bind
 			}).bind(this),
 		};
 	}

--- a/test.js
+++ b/test.js
@@ -84,9 +84,9 @@ class ThrowingIterator {
 					index++;
 					this.index = index;
 				}
-				// eslint is wrong - bind is needed else the next() call cannot update
-				// this.index, which we need to track how many times the iterator was called
-				// eslint-disable-next-line no-extra-bind
+			// eslint is wrong - bind is needed else the next() call cannot update
+			// this.index, which we need to track how many times the iterator was called
+			// eslint-disable-next-line no-extra-bind
 			}).bind(this),
 		};
 	}


### PR DESCRIPTION
Main differences from `pMap()`:

- Skipped values are simply never yielded
- `stopOnError` is not available because this can now be done by the user themselves
- `signal` is also not available for the same reason
- Values that are yielded from the iterator, are immediately passed to the mapper and the returned values are yielded from the function in the order that they originally were yielded

If you're ok with this, I'll add docs and tests

Fixes https://github.com/sindresorhus/promise-fun/issues/21