### PR TITLE
Fix pMapIterable when accepting async values in an iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ export function pMapIterable(
 					trySpawn();
 
 					try {
-						const returnValue = await mapper(value);
+						const returnValue = await mapper(await value);
 
 						runningMappersCount--;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,6 +7,33 @@ const sites = [
 	'https://github.com',
 ];
 
+const sitesWithPromises = [
+	'https://sindresorhus.com',
+	Promise.resolve('https://avajs.dev'),
+	Promise.resolve('https://github.com'),
+];
+
+const sitesAsyncIterable = {
+	async * [Symbol.asyncIterator]() {
+		yield 'https://sindresorhus.com';
+		yield 'https://avajs.dev';
+		yield 'https://github.com';
+	},
+};
+
+const sitesAsyncIterableWithPromises: AsyncIterable<Promise<string>> = {
+	[Symbol.asyncIterator]() {
+		return {
+			async next() {
+				return {
+					done: false,
+					value: Promise.resolve('https://github.com'),
+				};
+			},
+		};
+	},
+};
+
 const numbers = [
 	0,
 	1,
@@ -50,3 +77,6 @@ expectType<Promise<number[]>>(pMap(numbers, (number: number) => {
 }));
 
 expectType<AsyncIterable<string>>(pMapIterable(sites, asyncMapper));
+expectType<AsyncIterable<string>>(pMapIterable(sitesWithPromises, asyncMapper));
+expectType<AsyncIterable<string>>(pMapIterable(sitesAsyncIterable, asyncMapper));
+expectType<AsyncIterable<string>>(pMapIterable(sitesAsyncIterableWithPromises, asyncMapper));

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ import pMap, {pMapIterable, pMapSkip} from './index.js';
 const sharedInput = [
 	[async () => 10, 300],
 	[20, 200],
-	[30, 100],
+	Promise.resolve([30, 100]),
 ];
 
 const longerSharedInput = [


### PR DESCRIPTION
Hey,
Changed the shared input to include a promise as this is the sample in the basic usage.
I also fixed `pMapIterable` to await on values as it's type allows `Iterator<Element | Promise<Element>>`.
The tests cover this fix.

Related to https://github.com/sindresorhus/p-filter/pull/8

Thanks!
