### PR TITLE
`pMapIterable` `preserveOrder` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,39 @@ export type IterableOptions = BaseOptions & {
 	Default: `options.concurrency`
 	*/
 	readonly backpressure?: number;
+
+	/**
+	Whether the output iterable should produce the results of the `mapper` on elements of the `input` iterable in the same order as the elements were produced.
+
+	If `false`, `mapper` results will be produced in the order they are available, which may not match the order the `mapper` inputs were produced by the `input` iterable, but may improve throughput.
+
+	@example
+	```
+	import {pMapIterable} from 'p-map';
+	import delay from 'delay';
+
+	const orderPreservingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+		await delay(delayMs);
+		return value;
+	}, {concurrency: 2, preserveOrder: true});
+	// t=0ms
+	await orderPreservingIterator.next(); // 1 produced at t=100ms
+	await orderPreservingIterator.next(); // 2 produced at t=100ms
+	await orderPreservingIterator.next(); // 3 produced at t=105ms
+
+	const throughputOptimizingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+		await delay(delayMs);
+		return value;
+	}, {concurrency: 2, preserveOrder: false});
+	// t=0ms
+	await throughputOptimizingIterator.next(); // 2 produced at t=10ms
+	await throughputOptimizingIterator.next(); // 3 produced at t=15ms
+	await throughputOptimizingIterator.next(); // 1 produced at t=100ms
+	```
+
+	@default `true`
+	*/
+	readonly preserveOrder?: boolean;
 };
 
 type MaybePromise<T> = T | Promise<T>;

--- a/index.js
+++ b/index.js
@@ -168,6 +168,7 @@ export function pMapIterable(
 	{
 		concurrency = Number.POSITIVE_INFINITY,
 		backpressure = concurrency,
+		preserveOrder = true,
 	} = {},
 ) {
 	if (iterable[Symbol.iterator] === undefined && iterable[Symbol.asyncIterator] === undefined) {
@@ -186,84 +187,177 @@ export function pMapIterable(
 		throw new TypeError(`Expected \`backpressure\` to be an integer from \`concurrency\` (${concurrency}) and up or \`Infinity\`, got \`${backpressure}\` (${typeof backpressure})`);
 	}
 
+	if (typeof preserveOrder !== 'boolean') {
+		throw new TypeError(`Expected \`preserveOrder\` to be a boolean, got \`${preserveOrder}\` (${typeof preserveOrder})`);
+	}
+
 	return {
 		async * [Symbol.asyncIterator]() {
 			const iterator = iterable[Symbol.asyncIterator] === undefined ? iterable[Symbol.iterator]() : iterable[Symbol.asyncIterator]();
 
 			const promises = [];
+			const promisesIndexFromInputIndex = {};
+			const inputIndexFromPromisesIndex = [];
 			let runningMappersCount = 0;
 			let isDone = false;
-			let index = 0;
+			let inputIndex = 0;
+			let outputIndex = 0; // Only used when `preserveOrder: false`
+
+			const nextPromise = preserveOrder
+				// Treat `promises` as a queue
+				? () => {
+					// May be undefined bc of `pMapSkip`s
+					while (promisesIndexFromInputIndex[outputIndex] === undefined) {
+						outputIndex += 1;
+					}
+
+					return promises[promisesIndexFromInputIndex[outputIndex++]];
+				}
+				// Treat `promises` as a pool (order doesn't matter)
+				: () => Promise.race(promises);
+
+			function popPromise(inputIndex) {
+				// Swap the fulfilled promise with the last element to avoid an O(n) shift to the `promises` array
+				const tail = promises.pop();
+				const tailInputIndex = inputIndexFromPromisesIndex.pop();
+				const promisesIndex = promisesIndexFromInputIndex[inputIndex];
+				delete promisesIndexFromInputIndex[inputIndex];
+
+				if (promisesIndex !== promises.length) {
+					promises[promisesIndex] = tail;
+					inputIndexFromPromisesIndex[promisesIndex] = tailInputIndex;
+					promisesIndexFromInputIndex[tailInputIndex] = promisesIndex;
+				}
+			}
+
+			async function mapNext(promisesIndex) {
+				let next = iterator.next();
+
+				const myInputIndex = inputIndex++; // Save this promise's index before `trySpawn`ing others
+				runningMappersCount++;
+				promisesIndexFromInputIndex[myInputIndex] = promisesIndex;
+				inputIndexFromPromisesIndex[promisesIndex] = myInputIndex;
+
+				if (isPromiseLike(next)) {
+					// Optimization: if our concurrency and/or backpressure is bounded (so that we won't infinitely recurse),
+					// and we need to `await` the next `iterator` element, we first eagerly spawn more `mapNext` promises,
+					// so that these promises can begin `await`ing their respective `iterator` elements (if needed) and `mapper` results in parallel.
+					// This may entail memory usage closer to `options.backpressure` than necessary, but this space was already allocated to `pMapIterable` via
+					// `options.concurrency` and `options.backpressure`.
+					// This may also cause iteration well past the end of the `iterator`: we don't inspect the `iterator`'s response before `trySpawn`ing
+					// (because we are `trySpawn`ing before `await`ing the response), which will request the next `iterator` element, so we may end up spawning many promises which resolve to `done`.
+					// However, the time needed to `await` and ignore these `done` promises is presumed to be small relative to the time needed to perform common
+					// `async` operations like disk reads, network requests, etc.
+					// Overall, this can reduce the total time taken to process all elements.
+					if (backpressure !== Number.POSITIVE_INFINITY) {
+						// Spawn if still below concurrency and backpressure limit
+						trySpawn();
+					}
+
+					try {
+						next = await next;
+					} catch (error) {
+						isDone = true;
+						return {result: {error}, inputIndex: myInputIndex};
+					}
+				}
+
+				let {done, value} = next;
+
+				if (done) {
+					isDone = true;
+					return {result: {done: true}, inputIndex: myInputIndex};
+				}
+
+				// Spawn if still below concurrency and backpressure limit
+				trySpawn();
+
+				let returnValue;
+				try {
+					if (isPromiseLike(value)) {
+						value = await value;
+					}
+
+					returnValue = mapper(value, myInputIndex);
+					if (isPromiseLike(returnValue)) {
+						returnValue = await returnValue;
+					}
+				} catch (error) {
+					isDone = true;
+					return {result: {error}, inputIndex: myInputIndex};
+				}
+
+				runningMappersCount--;
+
+				if (returnValue === pMapSkip) {
+					// If `preserveOrder: true`, resolve to the next inputIndex's promise, in case we are already being `await`ed
+					// NOTE: no chance that `myInputIndex + 1`-spawning code is waiting to be executed in another part of the event loop,
+					// but currently `promisesIndexFromInputIndex[myInputIndex + 1] === undefined` (so that we incorrectly `mapNext` and
+					// this potentially-currently-awaited promise resolves to the result of mapping a later element than a different member of
+					// `promises`, i.e. `promises` resolve out of order), because all `trySpawn`/`mapNext` calls execute the bookkeeping synchronously,
+					// before any `await`s.
+					if (preserveOrder && promisesIndexFromInputIndex[myInputIndex + 1] !== undefined) {
+						popPromise(myInputIndex);
+						return promises[promisesIndexFromInputIndex[myInputIndex + 1]];
+					}
+
+					// Otherwise, start mapping the next input element
+					delete promisesIndexFromInputIndex[myInputIndex];
+					// Not necessary to `delete inputIndexFromPromisesIndex[promisesIndex]` since `inputIndexFromPromisesIndex[promisesIndex]` is only used
+					// when this promise resolves, but by that point this recursive `mapNext(promisesIndex)` call will have necessarily overwritten it.
+					return mapNext(promisesIndex);
+				}
+
+				// Spawn if still below backpressure limit and just dropped below concurrency limit
+				trySpawn();
+
+				return {result: {value: returnValue}, inputIndex: myInputIndex};
+			}
 
 			function trySpawn() {
 				if (isDone || !(runningMappersCount < concurrency && promises.length < backpressure)) {
 					return;
 				}
 
-				const promise = (async () => {
-					const {done, value} = await iterator.next();
-
-					if (done) {
-						return {done: true};
-					}
-
-					runningMappersCount++;
-
-					// Spawn if still below concurrency and backpressure limit
-					trySpawn();
-
-					try {
-						const returnValue = await mapper(await value, index++);
-
-						runningMappersCount--;
-
-						if (returnValue === pMapSkip) {
-							const index = promises.indexOf(promise);
-
-							if (index > 0) {
-								promises.splice(index, 1);
-							}
-						}
-
-						// Spawn if still below backpressure limit and just dropped below concurrency limit
-						trySpawn();
-
-						return {done: false, value: returnValue};
-					} catch (error) {
-						isDone = true;
-						return {error};
-					}
-				})();
-
-				promises.push(promise);
+				// Reserve index in `promises` array: we don't actually have the promise to save yet,
+				// but we don't want recursive `trySpawn` calls to use this same index.
+				// This is safe (i.e., the empty slot won't be `await`ed) because we replace the value immediately,
+				// without yielding to the event loop, so no consumers (namely `getAndRemoveFromPoolNextPromise`)
+				// can observe the intermediate state.
+				const promisesIndex = promises.length++;
+				promises[promisesIndex] = mapNext(promisesIndex);
 			}
 
 			trySpawn();
 
 			while (promises.length > 0) {
-				const {error, done, value} = await promises[0]; // eslint-disable-line no-await-in-loop
-
-				promises.shift();
+				const {result: {error, done, value}, inputIndex} = await nextPromise();// eslint-disable-line no-await-in-loop
+				popPromise(inputIndex);
 
 				if (error) {
 					throw error;
 				}
 
 				if (done) {
+					// When `preserveOrder: false`, ignore to consume any remaining pending promises in the pool
+					if (!preserveOrder) {
+						continue;
+					}
+
 					return;
 				}
 
 				// Spawn if just dropped below backpressure limit and below the concurrency limit
 				trySpawn();
 
-				if (value === pMapSkip) {
-					continue;
-				}
-
 				yield value;
 			}
 		},
 	};
+}
+
+function isPromiseLike(p) {
+	return typeof p === 'object' && p !== null && 'then' in p && typeof p.then === 'function';
 }
 
 export const pMapSkip = Symbol('skip');

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,39 @@ Maximum number of promises returned by `mapper` that have resolved but not yet c
 
 Useful whenever you are consuming the iterable slower than what the mapper function can produce concurrently. For example, to avoid making an overwhelming number of HTTP requests if you are saving each of the results to a database.
 
+##### preserveOrder
+
+**Only for `pMapIterable`**
+
+Type: `boolean`\
+Default: `true`
+
+Whether the output iterable should produce the results of the `mapper` on elements of the `input` iterable in the same order as the elements were produced.
+If `false`, `mapper` results will be produced in the order they are available, which may not match the order the `mapper` inputs were produced by the `input` iterable, but may improve throughput.
+
+```js
+import {pMapIterable} from 'p-map';
+import delay from 'delay';
+
+const orderPreservingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+	await delay(delayMs);
+	return value;
+}, {concurrency: 2, preserveOrder: true});
+// t=0ms
+await orderPreservingIterator.next(); // 1 produced at t=100ms
+await orderPreservingIterator.next(); // 2 produced at t=100ms
+await orderPreservingIterator.next(); // 3 produced at t=105ms
+
+const throughputOptimizingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+	await delay(delayMs);
+	return value;
+}, {concurrency: 2, preserveOrder: false});
+// t=0ms
+await throughputOptimizingIterator.next(); // 2 produced at t=10ms
+await throughputOptimizingIterator.next(); // 3 produced at t=15ms
+await throughputOptimizingIterator.next(); // 1 produced at t=100ms
+```
+
 ##### stopOnError
 
 **Only for `pMap`**


### PR DESCRIPTION
## Summary

Adds a `preserveOrder` option to `pMapIterable`, which indicates

> Whether the output iterable should produce the results of the `mapper` on elements of the `input` iterable in the same order as the elements were produced.
> If `false`, `mapper` results will be produced in the order they are available, which may not match the order the `mapper` inputs were produced by the `input` iterable, but may improve throughput.
> Type: `boolean`\
> Default: `true`

Addresses #72.

This implementation a bit more complicated than I expected, and I discovered several edge cases and race conditions along the way, so I encourage careful review and the suggestion/addition of more appropriate test cases.


## Implementation considerations

In order to
  - (a) treat `promises` as an unordered pool for use with `Promise.race` and
  - (b) avoid an `O(min(concurrency, backpressure))` `promises.indexOf` to know which `promise` to remove from `promises`,

the promise itself must return some identifying information. The promise's `inputIndex` is good for this purpose as it is a stable id that will not change when shuffling `promises` around. However, `inputIndex` alone is not enough to determine which member of `promises` has returned, so we also introduce extra bookkeeping `promisesIndexFromInputIndex` information. In order to correctly record `promisesIndexFromInputIndex` during `mapNext`, we "reserve" a spot  in the `promises` array during `trySpawn` (from recursive `trySpawn` calls in particular, before we would've had a chance to `promises.push(mapNext())`, since the inner `mapNext()` expression executes additional `trySpawn`s before we can perform the outer `.push` expression) by incrementing its length, so that we can use `promises.length` to determine `promisesIndex`.

Then, to avoid an `O(min(concurrency, backpressure))` `promises.splice` to remove the resolved promise, we instead swap the resolved promise with `promises[promises.length - 1]`. We could also overwrite the resolved member of `promises` in-place, but it seemed slightly cleaner to do it this way so we could reuse this logic in the `pMapSkip + preserveOrder: true` case where we currently `indexOf` + `splice`. In order to make the aforementioned swap, though, we need to update our `promisesIndexFromInputIndex` ledger: however, we cannot know `promises[promises.length - 1]`'s input index without extra information, so we introduce an additional `inputIndexFromPromisesIndex` record.

Speaking of which, to unify the `preserveOrder: false` logic with the `preserveOrder: true` case, for the latter we still treat the `promises` array in the same pool-fashion, where the result of mapping any `inputIndex` might end up anywhere in `promises`, but bookkeep an additional `outputIndex` datum to use in conjunction with `promisesIndexFromInputIndex` to determine which promise is next in sequence (and so `await` and process). As mentioned earlier, this pool-based pattern also allows us to handle the `pMapSkip` case in an `O(1)` manner, compared to the existing `indexOf` + `splice` strategy.

Further, `pMapSkip` is now handled within one of the `promises` itself, instead of in the main `while` loop. This is done by breaking out the IIFE assigned to `promise` into a `mapNext` function that can then be called recursively when `pMapSkip` is returned. However, we must also consider the case that `preserveOrder: true` and the current promise is being `await`ed already: in this case, if `concurrency > 1` and we were to `mapNext`, the current promise would return the result of mapping an `iterable` element many `inputIndex`es in the future, failing to `preserveOrder`. Thus, we check if the `myInputIndex + 1` mapper is running, and if so, return its promise after removing our current promise from `promises`: thus when the current promise returns we will process and remove the `myInputIndex + 1` promise, as if we had `await promises[promisesIndexFromInputIndex[myInputIndex + 1]]`ed. But now our `outputIndex` is behind (it think we should return the promise for `myInputIndex + 1` next, but we skipped that one, so we should return the promise for `myInputIndex + 2` instead), so to compensate, we skip indices with `promisesIndexFromInputIndex[outputIndex] === undefined`.

As a last piece of miscellany, when `preserveOrder: false && (await nextPromise()).result.done === true`, stopping the async iterable is no longer safe, since other `promises` may still be pending in the array. So, we `continue` in this case. 

Finally, I made other small optimizations where I spotted an opportunity, like only `await`ing when necessary and `trySpawn`ing before `await`ing the input `iterable`'s `.next` response, in case we can start another promise chugging, too.