### PR TITLE
Unoptimized implementation of `pMapIterable` `preserveOrder` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,39 @@ export type IterableOptions = BaseOptions & {
 	Default: `options.concurrency`
 	*/
 	readonly backpressure?: number;
+
+	/**
+	Whether the output iterable should produce the results of the `mapper` on elements of the `input` iterable in the same order as the elements were produced.
+
+	If `false`, `mapper` results will be produced in the order they are available, which may not match the order the `mapper` inputs were produced by the `input` iterable, but may improve throughput.
+
+	@example
+	```
+	import {pMapIterable} from 'p-map';
+	import delay from 'delay';
+
+	const orderPreservingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+		await delay(delayMs);
+		return value;
+	}, {concurrency: 2, preserveOrder: true});
+	// t=0ms
+	await orderPreservingIterator.next(); // 1 produced at t=100ms
+	await orderPreservingIterator.next(); // 2 produced at t=100ms
+	await orderPreservingIterator.next(); // 3 produced at t=105ms
+
+	const throughputOptimizingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+		await delay(delayMs);
+		return value;
+	}, {concurrency: 2, preserveOrder: false});
+	// t=0ms
+	await throughputOptimizingIterator.next(); // 2 produced at t=10ms
+	await throughputOptimizingIterator.next(); // 3 produced at t=15ms
+	await throughputOptimizingIterator.next(); // 1 produced at t=100ms
+	```
+
+	@default `true`
+	*/
+	readonly preserveOrder?: boolean;
 };
 
 type MaybePromise<T> = T | Promise<T>;

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,39 @@ Maximum number of promises returned by `mapper` that have resolved but not yet c
 
 Useful whenever you are consuming the iterable slower than what the mapper function can produce concurrently. For example, to avoid making an overwhelming number of HTTP requests if you are saving each of the results to a database.
 
+##### preserveOrder
+
+**Only for `pMapIterable`**
+
+Type: `boolean`\
+Default: `true`
+
+Whether the output iterable should produce the results of the `mapper` on elements of the `input` iterable in the same order as the elements were produced.
+If `false`, `mapper` results will be produced in the order they are available, which may not match the order the `mapper` inputs were produced by the `input` iterable, but may improve throughput.
+
+```js
+import {pMapIterable} from 'p-map';
+import delay from 'delay';
+
+const orderPreservingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+	await delay(delayMs);
+	return value;
+}, {concurrency: 2, preserveOrder: true});
+// t=0ms
+await orderPreservingIterator.next(); // 1 produced at t=100ms
+await orderPreservingIterator.next(); // 2 produced at t=100ms
+await orderPreservingIterator.next(); // 3 produced at t=105ms
+
+const throughputOptimizingIterator = pMapIterable([[1, 100], [2, 10], [3, 5]], async ([value, delayMs]) => {
+	await delay(delayMs);
+	return value;
+}, {concurrency: 2, preserveOrder: false});
+// t=0ms
+await throughputOptimizingIterator.next(); // 2 produced at t=10ms
+await throughputOptimizingIterator.next(); // 3 produced at t=15ms
+await throughputOptimizingIterator.next(); // 1 produced at t=100ms
+```
+
 ##### stopOnError
 
 **Only for `pMap`**

--- a/test.js
+++ b/test.js
@@ -102,6 +102,10 @@ class ThrowingIterator {
 	}
 }
 
+function rangeAround(expected) {
+	return {start: expected - 5, end: expected + 50};
+}
+
 test('main', async t => {
 	const end = timeSpan();
 	t.deepEqual(await pMap(sharedInput, mapper), [10, 20, 30]);
@@ -545,7 +549,7 @@ test('pMapIterable - empty', async t => {
 	t.deepEqual(await collectAsyncIterable(pMapIterable([], mapper)), []);
 });
 
-test('pMapIterable - iterable that throws', async t => {
+test('pMapIterable - async iterable that throws', async t => {
 	let isFirstNextCall = true;
 
 	const iterable = {
@@ -562,14 +566,27 @@ test('pMapIterable - iterable that throws', async t => {
 			};
 		},
 	};
-
 	const iterator = pMapIterable(iterable, mapper)[Symbol.asyncIterator]();
-
 	await t.throwsAsync(iterator.next(), {message: 'foo'});
 });
 
-test('pMapIterable - mapper that throws', async t => {
+test('pMapIterable - sync iterable that throws', async t => {
+	function * throwingGenerator() { // eslint-disable-line require-yield
+		throw new Error('foo');
+	}
+
+	const iterator = pMapIterable(throwingGenerator(), mapper)[Symbol.asyncIterator]();
+	await t.throwsAsync(() => iterator.next(), {message: 'foo'});
+});
+
+test('pMapIterable - async mapper that throws', async t => {
 	await t.throwsAsync(collectAsyncIterable(pMapIterable(sharedInput, async () => {
+		throw new Error('foo');
+	})), {message: 'foo'});
+});
+
+test('pMapIterable - sync mapper that throws', async t => {
+	await t.throwsAsync(collectAsyncIterable(pMapIterable(sharedInput, () => {
 		throw new Error('foo');
 	})), {message: 'foo'});
 });
@@ -607,9 +624,9 @@ test('pMapIterable - concurrency: 2', async t => {
 
 	assertInRange(t, times.get(10), {start: 0, end: 50});
 	assertInRange(t, times.get(20), {start: 0, end: 50});
-	assertInRange(t, times.get(30), {start: 200, end: 250});
-	assertInRange(t, times.get(40), {start: 300, end: 350});
-	assertInRange(t, times.get(50), {start: 300, end: 350});
+	assertInRange(t, times.get(30), rangeAround(200));
+	assertInRange(t, times.get(40), rangeAround(300));
+	assertInRange(t, times.get(50), rangeAround(300));
 });
 
 test('pMapIterable - backpressure', async t => {
@@ -637,10 +654,218 @@ test('pMapIterable - backpressure', async t => {
 	t.is(currentValue, 40);
 });
 
-test('pMapIterable - pMapSkip', async t => {
+test('pMapIterable - complex pMapSkip pattern - concurrency 1', async t => {
 	t.deepEqual(await collectAsyncIterable(pMapIterable([
-		1,
 		pMapSkip,
+		1,
 		2,
-	], async value => value)), [1, 2]);
+		3,
+		pMapSkip,
+		4,
+		5,
+		pMapSkip,
+		pMapSkip,
+		6,
+		7,
+		8,
+		pMapSkip,
+	], async value => value)), [1, 2, 3, 4, 5, 6, 7, 8]);
+});
+
+test('pMapIterable - complex pMapSkip pattern - concurrency 2', async t => {
+	t.deepEqual(await collectAsyncIterable(pMapIterable([
+		pMapSkip,
+		1,
+		2,
+		3,
+		pMapSkip,
+		4,
+		5,
+		pMapSkip,
+		pMapSkip,
+		6,
+		7,
+		8,
+		pMapSkip,
+	], async value => value, {concurrency: 2})), [1, 2, 3, 4, 5, 6, 7, 8]);
+});
+
+test('pMapIterable - complex pMapSkip pattern - concurrency 2 - preserveOrder: false', async t => {
+	const result = await collectAsyncIterable(pMapIterable([
+		pMapSkip,
+		1,
+		2,
+		3,
+		pMapSkip,
+		4,
+		5,
+		pMapSkip,
+		pMapSkip,
+		6,
+		7,
+		8,
+		pMapSkip,
+	], async value => value, {concurrency: 2, preserveOrder: false}));
+	const resultSet = new Set(result);
+	t.assert(resultSet.has(1));
+	t.assert(resultSet.has(2));
+	t.assert(resultSet.has(3));
+	t.assert(resultSet.has(4));
+	t.assert(resultSet.has(5));
+	t.assert(resultSet.has(6));
+	t.assert(resultSet.has(7));
+	t.assert(resultSet.has(8));
+	t.assert(result.length === 8);
+});
+
+test('pMapIterable - pMapSkip + preserveOrder: true + next input mapping promise pending - eagerly spawns next promise', async t => {
+	const end = timeSpan();
+	const testData = [
+		[pMapSkip, 100],
+		[2, 200],
+		[3, 100], // Ensure 3 is spawned when pMapSkip ends (otherwise, overall runtime will be 300 ms)
+	];
+	const result = await collectAsyncIterable(pMapIterable(testData, mapper, {preserveOrder: true, concurrency: 2}));
+	assertInRange(t, end(), rangeAround(200));
+	t.deepEqual(result, [2, 3]);
+});
+
+test('pMapIterable - async iterable input', async t => {
+	const result = await collectAsyncIterable(pMapIterable(new AsyncTestData(sharedInput), mapper));
+	t.deepEqual(result, [10, 20, 30]);
+});
+
+test('pMapIterable - pMapSkip + preserveOrder: true - preserves order, even when next input needs to be awaited', async t => {
+	const result = await collectAsyncIterable(pMapIterable([1, 2, 3], (_value, index) => {
+		switch (index) {
+			case 0: {
+				return pMapSkip;
+			}
+
+			case 1: {
+				return delay(100, {value: 2});
+			}
+
+			case 2: {
+				return 3;
+			}
+
+			default: {
+				return undefined;
+			}
+		}
+	}, {concurrency: 2, preserveOrder: true}));
+	t.deepEqual(result, [2, 3]);
+});
+
+test('pMapIterable - preserveOrder: false - yields mappings as they resolve', async t => {
+	const end = timeSpan();
+	const result = await collectAsyncIterable(pMapIterable(sharedInput, mapper, {preserveOrder: false}));
+	t.deepEqual(result, [30, 20, 10]);
+	assertInRange(t, end(), rangeAround(300));
+});
+
+test('pMapIterable - preserveOrder: false - more complex example - sync iterable and bounded concurrency', async t => {
+	t.deepEqual(await collectAsyncIterable(pMapIterable([
+		[1, 200],
+		[2, 100],
+		[3, 150],
+		[4, 200],
+		[5, 100],
+		[6, 75],
+	], mapper, {concurrency: 3, preserveOrder: false})), [2, 3, 1, 5, 6, 4]);
+});
+
+test('pMapIterable - preserveOrder: false - more complex example - async iterable and unbounded concurrency', async t => {
+	const testData = [
+		[1, 200],
+		[2, 125],
+		[3, 150],
+		[4, 200],
+		[5, 100],
+		[6, 75],
+	];
+	async function * asyncIterable() {
+		yield * testData;
+	}
+
+	const sortedTestData = structuredClone(testData).sort(([_aId, aMs], [_bId, bMs]) => aMs - bMs);
+
+	t.deepEqual(await collectAsyncIterable(pMapIterable(asyncIterable(), mapper, {concurrency: Number.POSITIVE_INFINITY, preserveOrder: false})), sortedTestData.map(([id, _ms]) => id));
+});
+
+test('pMapIterable - preserveOrder: false - more complex example - sync promise-returning iterable and unbounded concurrency', async t => {
+	const testData = [
+		[1, 200],
+		[2, 125],
+		[3, 150],
+		[4, 225],
+		[5, 100],
+		[6, 75],
+	];
+	function * syncPromiseReturningIterable() {
+		yield * testData.map(d => Promise.resolve(d));
+	}
+
+	const sortedTestData = structuredClone(testData).sort(([_aId, aMs], [_bId, bMs]) => aMs - bMs);
+
+	t.deepEqual(await collectAsyncIterable(pMapIterable(syncPromiseReturningIterable(), mapper, {concurrency: Number.POSITIVE_INFINITY, preserveOrder: false})), sortedTestData.map(([id, _ms]) => id));
+});
+
+test('pMapIterable - preserveOrder: false - concurrency: 2', async t => {
+	const input = [100, 200, 10, 36, 13, 45];
+	const times = new Map();
+	const end = timeSpan();
+
+	t.deepEqual(await collectAsyncIterable(pMapIterable(input, value => {
+		times.set(value, end());
+		return delay(value, {value});
+	}, {concurrency: 2, backpressure: Number.POSITIVE_INFINITY, preserveOrder: false})), [100, 10, 36, 13, 200, 45]);
+
+	assertInRange(t, times.get(100), rangeAround(0));
+	assertInRange(t, times.get(200), rangeAround(0));
+	assertInRange(t, times.get(10), rangeAround(times.get(100) + 100));
+	assertInRange(t, times.get(36), rangeAround(times.get(10) + 10));
+	assertInRange(t, times.get(13), rangeAround(times.get(36) + 36));
+	assertInRange(t, times.get(45), rangeAround(times.get(13) + 13));
+});
+
+test('pMapIterable - preserveOrder: false - backpressure', async t => {
+	// Adjust from 300 to 250 so timings don't align, to deflake
+	const adjustedLongerSharedInput = [...longerSharedInput];
+	adjustedLongerSharedInput[0] = [longerSharedInput[0][0], 250];
+
+	let currentValue;
+
+	// Concurrency option is forced by an early check
+	const asyncIterator = pMapIterable(adjustedLongerSharedInput, async value => {
+		currentValue = await mapper(value);
+		return currentValue;
+	}, {backpressure: 2, concurrency: 2, preserveOrder: false})[Symbol.asyncIterator]();
+
+	const {value: value1} = await asyncIterator.next();
+	t.is(value1, 20);
+
+	// If backpressure is not respected, than all items will be evaluated in this time
+	await delay(600);
+
+	t.is(currentValue, 30);
+
+	const {value: value2} = await asyncIterator.next();
+	t.is(value2, 10);
+
+	await delay(100);
+
+	t.is(currentValue, 40);
+});
+
+test('pMapIterable - preserveOrder: false - throws first error to settle', async t => {
+	await t.throwsAsync(collectAsyncIterable(pMapIterable([
+		[async () => {
+			throw new Error('foo');
+		}, 30],
+		[() => {
+			throw new Error('bar');
+		}, 10],
+	], mapper, {preserveOrder: false, concurrency: 2})), {message: 'bar'});
 });


### PR DESCRIPTION
Fixes #72.

Spun off from https://github.com/sindresorhus/p-map/pull/74 in light of 
- https://github.com/sindresorhus/p-map/pull/74#issuecomment-2129315601
- https://github.com/sindresorhus/p-map/pull/74#issuecomment-2311454598

## Summary

Adds a `preserveOrder` option to `pMapIterable`, which indicates

> Whether the output iterable should produce the results of the `mapper` on elements of the `input` iterable in the same order as the elements were produced.
> If `false`, `mapper` results will be produced in the order they are available, which may not match the order the `mapper` inputs were produced by the `input` iterable, but may improve throughput.
> Type: `boolean`\
> Default: `true`



## Implementation considerations

- `promise` must return reference to itself so `popRandomPromise` can find `indexOf`.
- When `preserveOrder: false`, racing the `promises` pool is not enough, since `trySpawn` may be add additional promises to the buffer after the race has begun: so we race an event listener alongside (`promises` pool is still needed to buffer multiple promises finishing simultaneously.
-  When `returnValue === pMapSkip && preserveOrder: false`, unlike when `preserveOrder: false` we have no way to know if returning will cause our `promise` to win an ongoing race, and so have no way of knowing whether to skip popping ourselves (to allow the main loop to pop us instead). So, when `returnValue === pMapSkip`, we instead `popRandomPromise` ourselves unconditionally and instead skip `popNextPromise` in main `while` loop.
- move `promise` inner `try-catch` logic to `promise.catch` (which now also catches when `iterator.next()` throws)
- when `preserveOrder: false && result.done`, some promises in the pool may still be pending, so `continue` (as a matter of fact, we could probably `continue` in all cases since the current implementation does not run concurrent `iterator.next` calls, so if `preserveOrder: true && result.done` there should be no remaining `promises` in the queue - but hopefully that will change soon as [we think about concurrent `iterator.next` calls](https://github.com/sindresorhus/p-map/pull/77#issuecomment-2290862306)!