### PR TITLE
Upgrade 'xo' to 1.2.3 (from 0.56) and Node to 20.17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 24
+          - 22
           - 20
-          - 18
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export default async function pMap(
 		signal,
 	} = {},
 ) {
-	return new Promise((resolve_, reject_) => {
+	return new Promise((_resolve, _reject) => {
 		if (iterable[Symbol.iterator] === undefined && iterable[Symbol.asyncIterator] === undefined) {
 			throw new TypeError(`Expected \`input\` to be either an \`Iterable\` or \`AsyncIterable\`, got (${typeof iterable})`);
 		}
@@ -39,14 +39,14 @@ export default async function pMap(
 		};
 
 		const resolve = value => {
-			resolve_(value);
+			_resolve(value);
 			cleanup();
 		};
 
 		const reject = reason => {
 			isRejected = true;
 			isResolved = true;
-			reject_(reason);
+			_reject(reason);
 			cleanup();
 		};
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,10 @@
 import {expectType, expectAssignable} from 'tsd';
-import pMap, {pMapIterable, type Options, type Mapper, pMapSkip} from './index.js';
+import pMap, {
+	pMapIterable,
+	type Options,
+	type Mapper,
+	pMapSkip,
+} from './index.js';
 
 const sites = [
 	'https://sindresorhus.com',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18"
+		"node": ">=20.17"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -52,6 +52,6 @@
 		"random-int": "^3.0.0",
 		"time-span": "^5.1.0",
 		"tsd": "^0.29.0",
-		"xo": "^0.56.0"
+		"xo": "^1.2.3"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -205,16 +205,15 @@ test('all pMapSkips', async t => {
 test('all mappers should run when concurrency is infinite, even after stop-on-error happened', async t => {
 	const input = [1, async () => delay(300, {value: 2}), 3];
 	const mappedValues = [];
-	await t.throwsAsync(
-		pMap(input, async value => {
-			value = typeof value === 'function' ? await value() : value;
-			mappedValues.push(value);
-			if (value === 1) {
-				await delay(100);
-				throw new Error('Oops!');
-			}
-		}),
-	);
+	const promise = pMap(input, async value => {
+		value = typeof value === 'function' ? await value() : value;
+		mappedValues.push(value);
+		if (value === 1) {
+			await delay(100);
+			throw new Error('Oops!');
+		}
+	});
+	await t.throwsAsync(promise);
 	await delay(500);
 	t.deepEqual(mappedValues, [1, 3, 2]);
 });
@@ -468,15 +467,12 @@ test('no unhandled rejected promises from mapper throws - infinite concurrency',
 test('no unhandled rejected promises from mapper throws - concurrency 1', async t => {
 	const input = [1, 2, 3];
 	const mappedValues = [];
-	await t.throwsAsync(
-		pMap(input, async value => {
-			mappedValues.push(value);
-			await delay(100);
-			throw new Error(`Oops! ${value}`);
-		},
-		{concurrency: 1}),
-		{message: 'Oops! 1'},
-	);
+	const promise = pMap(input, async value => {
+		mappedValues.push(value);
+		await delay(100);
+		throw new Error(`Oops! ${value}`);
+	}, {concurrency: 1});
+	await t.throwsAsync(promise, {message: 'Oops! 1'});
 	t.deepEqual(mappedValues, [1]);
 });
 


### PR DESCRIPTION
This results in the dependency tree summary moving from 6 high severity vulnerabilities to 3 low severity.

xo 0.56 pulled in eslint 8, including several deprecated transitive deps with security and memory issues.
xo 1.x moved to eslint 9, resolving those issues, but requiring Node 20. (Node 18 went EOL mid last year.)

Bumped CI Node versions matrix to 20, 22, 24.
Includes a few small code changes to satisfy new lint rules in the new xo.