### PR TITLE
Fix `pMapIterable` mapper index for out-of-order promise inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,7 +226,8 @@ export function pMapIterable(
 					trySpawn();
 
 					try {
-						const returnValue = await mapper(await value, index++);
+						const currentIndex = index++;
+						const returnValue = await mapper(await value, currentIndex);
 
 						pendingPromisesCount--;
 

--- a/test.js
+++ b/test.js
@@ -541,6 +541,21 @@ test('pMapIterable - index in mapper', async t => {
 	]);
 });
 
+test('pMapIterable - index in mapper (out-of-order-settling promises)', async t => {
+	const input = [
+		delay(50, {value: 'a'}),
+		delay(10, {value: 'b'}),
+		delay(30, {value: 'c'}),
+	];
+
+	const result = [];
+	for await (const item of pMapIterable(input, async (value, index) => [value, index], {concurrency: 3})) {
+		result.push(item);
+	}
+
+	t.deepEqual(result, [['a', 0], ['b', 1], ['c', 2]]);
+});
+
 test('pMapIterable - empty', async t => {
 	t.deepEqual(await collectAsyncIterable(pMapIterable([], mapper)), []);
 });


### PR DESCRIPTION
`pMapIterable` hands the mapper the wrong `index` when the input is promises that settle out of order. The index is meant to be the element's position in the source (the way `pMap` does it), but it ends up numbered in the order the promises happen to resolve.

```js
import {pMapIterable} from 'p-map';
import delay from 'delay';

const input = [delay(50, {value: 'a'}), delay(10, {value: 'b'}), delay(30, {value: 'c'})];

const result = [];
for await (const item of pMapIterable(input, (value, index) => [value, index], {concurrency: 3})) {
	result.push(item);
}

result;
//=> [['a', 2], ['b', 0], ['c', 1]]   — should be [['a', 0], ['b', 1], ['c', 2]]
```

`pMap` returns the right indices for the same input.

The reason is that `index++` runs as an argument to `mapper`, so it's evaluated *after* `await value`:

```js
const returnValue = await mapper(await value, index++);
```

Workers are spawned in source order, but each one suspends on `await value` until its promise settles, so the shared counter gets read in settlement order instead. `pMap` avoids this by capturing the index when it pulls the item off the iterator, before awaiting it.

The fix is to do the same here — grab the index at spawn time:

```js
const currentIndex = index++;
const returnValue = await mapper(await value, currentIndex);
```

Only the index the mapper sees changes; output ordering, concurrency, backpressure, and `pMapSkip` are all untouched. I also added a test with out-of-order-settling promises that asserts the index follows source order (it fails before this change and passes after).
