### PR TITLE
Fix abort listener cleanup for already-aborted signals

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ export default async function pMap(
 		if (signal) {
 			if (signal.aborted) {
 				reject(signal.reason);
+				return;
 			}
 
 			signal.addEventListener('abort', signalListener, {once: true});

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import {getEventListeners} from 'node:events';
 import test from 'ava';
 import delay from 'delay';
 import timeSpan from 'time-span';
@@ -509,6 +510,7 @@ if (globalThis.AbortController !== undefined) {
 		await t.throwsAsync(pMap([delay(1000), new AsyncTestData(100), 100], mapper, {signal: abortController.signal}), {
 			name: 'AbortError',
 		});
+		t.is(getEventListeners(abortController.signal, 'abort').length, 0);
 	});
 }
 


### PR DESCRIPTION
## Summary

- stop setup after rejecting an already-aborted signal
- verify that no abort listener remains attached after rejection

## Problem

When `pMap()` receives an already-aborted signal, it rejects and runs listener cleanup before the listener has been registered. Execution then continues and registers the listener after the returned promise has already settled, leaving it attached to a reused signal.

## Fix

Return immediately after rejecting the already-aborted signal. The existing listener setup and cleanup behavior for active signals is unchanged.

## Testing

- `npx ava test.js --match="already aborted signal"`
- `npm test`
- full AVA suite on Node.js 18.20.8
- full AVA suite on Node.js 20.20.2
